### PR TITLE
Add thinking delay option

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -128,6 +128,9 @@
             <label for="delay-range"><img src="static/image/delay.png" alt="Delay"> Delay:
                 <input type="range" id="delay-range" min="0" max="5000" step="100" value="1000">
             </label>
+            <label for="thinking-delay-range"><img src="static/image/delay.png" alt="Thinking Delay"> Thinking delay:
+                <input type="range" id="thinking-delay-range" min="0" max="5000" step="100" value="500">
+            </label>
         </div>
         <div class="fullscreen-messages" id="fullscreen-messages"></div>
     </div>

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -7,6 +7,7 @@ class BotDialogGenerator {
     this.currentBatchCount = 0; // Количество сообщений в текущей пачке генерации
     this.generatedMessages = []; // Сгенерированные сообщения
     this.delayMs = 1000; // Задержка между воспроизведением сообщений
+    this.thinkingDelayMs = 500; // Задержка перед показом "Thinking..."
     this.isPlaying = false; // Флаг для отслеживания начала диалога
     this.currentIndex = 0;
     this.timeoutId = null;
@@ -144,6 +145,17 @@ class BotDialogGenerator {
       this.delayMs = parseInt(e.target.value, 10);
       this.logMessage(`Delay set to ${this.delayMs} ms`, "info");
     });
+
+    // Fullscreen thinking delay slider
+    document
+      .getElementById("thinking-delay-range")
+      ?.addEventListener("input", (e) => {
+        this.thinkingDelayMs = parseInt(e.target.value, 10);
+        this.logMessage(
+          `Thinking delay set to ${this.thinkingDelayMs} ms`,
+          "info"
+        );
+      });
 
     // Model selection
     document.querySelectorAll("select").forEach((select) => {
@@ -469,6 +481,8 @@ class BotDialogGenerator {
     // Генерируем именно messageLimit сообщений в каждой пачке
     while (this.currentBatchCount < this.messageLimit && !this.isPaused) {
       try {
+        // Небольшая задержка перед показом "Thinking..."
+        await this.delay(this.thinkingDelayMs);
         // Показываем индикатор "Thinking..."
         this.showThinkingIndicator(currentBot);
 
@@ -660,6 +674,9 @@ const showNextMessage = async () => {
     showNextMessage();
     return;
   }
+
+  // Небольшая задержка перед отображением Thinking
+  await delay(this.thinkingDelayMs);
 
   // Показываем Thinking...
   const isLeft = sender === "bot1";


### PR DESCRIPTION
## Summary
- allow configuration of a delay before displaying "Thinking..."
- add slider in the fullscreen menu to adjust thinking delay
- handle slider events in `setupEventListeners`
- wait for the thinking delay when generating or replaying bot messages

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68543bd244cc83268072aa1e02c0c039