### PR TITLE
Fix API key selectors

### DIFF
--- a/api/together.js
+++ b/api/together.js
@@ -1,8 +1,8 @@
 export default async function handler(req, res) {
-  const { systemPrompt, userPrompt, temperature, provider, mode } = req.body;
+  const { systemPrompt, userPrompt, temperature, provider, mode, apiKey } = req.body;
 
   // Безопасный доступ к Together AI ключу из переменной окружения
-  const TOGETHER_API_KEY = process.env.TOGETHER_API_KEY;
+  const TOGETHER_API_KEY = apiKey || process.env.TOGETHER_API_KEY;
 
   // Объект конфигураций провайдеров — дублируем тот, что был у тебя в JS
   const AI_PROVIDERS = {

--- a/chat.html
+++ b/chat.html
@@ -29,8 +29,8 @@
                         <label>Select model</label>
                         <select>
                             <option>TogetherAI</option>
-                            <!-- <option>GPT-4</option>
-                            <option>Gemini</option> -->
+                            <option>GPT-4</option>
+                            <option>Gemini</option>
                         </select>
                     </div>
 

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -289,6 +289,7 @@ class BotDialogGenerator {
                         <button class="clear-key" data-key="togetherai">
                             <img src="static/image/clear.png" alt="Delete">
                         </button>
+                        <button class="toggle-key" data-target="togetherai">👁️</button>
                     </div>
                     <div class="input-group">
                         <label>OpenAI API Key:</label>
@@ -296,6 +297,7 @@ class BotDialogGenerator {
                         <button class="clear-key" data-key="openai">
                             <img src="static/image/clear.png" alt="Delete">
                         </button>
+                        <button class="toggle-key" data-target="openai">👁️</button>
                     </div>
                     <div class="input-group">
                         <label>Google AI API Key:</label>
@@ -303,6 +305,7 @@ class BotDialogGenerator {
                         <button class="clear-key" data-key="google">
                             <img src="static/image/clear.png" alt="Delete">
                         </button>
+                        <button class="toggle-key" data-target="google">👁️</button>
                     </div>
                     <button class="save-keys">Save Keys</button>
                 </div>
@@ -351,6 +354,17 @@ class BotDialogGenerator {
       content.querySelectorAll(".clear-key").forEach((btn) => {
         btn.addEventListener("click", () => {
           this.clearApiKey(btn.dataset.key);
+        });
+      });
+
+      // Кнопки просмотра ключей
+      content.querySelectorAll(".toggle-key").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const target = btn.dataset.target;
+          const input = content.querySelector(`.${target}-key`);
+          if (input) {
+            input.type = input.type === "password" ? "text" : "password";
+          }
         });
       });
 

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -374,9 +374,12 @@ class BotDialogGenerator {
   }
 
   saveApiKeys() {
-    this.apiKeys.openai = document.getElementById("openai-key").value;
-    this.apiKeys.togetherai = document.getElementById("togetherai-key").value;
-    this.apiKeys.google = document.getElementById("google-key").value;
+    this.apiKeys.openai =
+      document.querySelector(".openai-key")?.value || "";
+    this.apiKeys.togetherai =
+      document.querySelector(".togetherai-key")?.value || "";
+    this.apiKeys.google =
+      document.querySelector(".google-key")?.value || "";
 
     this.logMessage("API keys saved successfully", "success");
   }

--- a/static/styles/chat_style.css
+++ b/static/styles/chat_style.css
@@ -1515,22 +1515,41 @@ body {
 }
 
 .api-keys-form .input-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin-bottom: 10px;
 }
 
 .api-keys-form label {
-    display: block;
-    margin-bottom: 5px;
+    min-width: 110px;
 }
 
 .api-keys-form input {
-    width: 100%;
+    flex: 1;
     padding: 5px;
     border: 1px solid #ccc;
     border-radius: 4px;
 }
 
-.api-keys-form button {
+.api-keys-form .clear-key {
+    background: none;
+    border: 1px solid #777;
+    border-radius: 6px;
+    padding: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.api-keys-form .clear-key img {
+    width: 16px;
+    height: 16px;
+}
+
+.api-keys-form .save-keys {
+    margin-top: 10px;
     background: linear-gradient(135deg, #3c3c3c, #5a5a5a);
     border: 1px solid #777;
     border-radius: 6px;
@@ -1542,14 +1561,14 @@ body {
     cursor: pointer;
 }
 
-.api-keys-form button:hover {
+.api-keys-form .save-keys:hover {
     background: linear-gradient(135deg, rgb(0, 143, 84), rgb(0, 131, 11));
     border-color: #aaa;
     color: #fff;
     transform: translateY(-1px);
 }
 
-.api-keys-form button:active {
+.api-keys-form .save-keys:active {
     background: #333;
     transform: translateY(1px);
 }

--- a/static/styles/chat_style.css
+++ b/static/styles/chat_style.css
@@ -1532,7 +1532,8 @@ body {
     border-radius: 4px;
 }
 
-.api-keys-form .clear-key {
+.api-keys-form .clear-key,
+.api-keys-form .toggle-key {
     background: none;
     border: 1px solid #777;
     border-radius: 6px;
@@ -1541,6 +1542,11 @@ body {
     align-items: center;
     justify-content: center;
     cursor: pointer;
+}
+
+.api-keys-form .toggle-key {
+    font-size: 16px;
+    line-height: 1;
 }
 
 .api-keys-form .clear-key img {


### PR DESCRIPTION
## Summary
- use `.openai-key`, `.togetherai-key`, and `.google-key` selectors when saving API keys

## Testing
- `node --check static/scripts/chat.js`
- `node test.js` *(custom script)*

------
https://chatgpt.com/codex/tasks/task_e_68544b9a632483268ff4eabda616b917