### PR TITLE
Improve API key flow and model display

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -21,6 +21,7 @@
             <div class="logs-section">
                 <div class="logs-header">Chat history cleared</div>
                 <div class="logs-header">Message counters have been reset</div>
+                <div class="logs-header model-info"></div>
             </div>
 
             <div class="settings-section"> <!-- Блок с настройками -->
@@ -28,9 +29,10 @@
                     <div class="control-group">
                         <label>Select model</label>
                         <select>
-                            <option>Open AI</option>
-                            <option>Together AI</option>
-                            <option>Gemini</option>
+                            <option value="" selected>Select model...</option>
+                            <option value="GPT-4">GPT-4</option>
+                            <option value="TogetherAI">TogetherAI</option>
+                            <option value="Gemini">Gemini</option>
                         </select>
                     </div>
 
@@ -195,9 +197,10 @@
                 <div class="mobile-control-group">
                     <label>Select model</label>
                     <select>
-                        <option>GPT-4</option>
-                        <option>TogetherAI</option>
-                        <option>Gemini</option>
+                        <option value="" selected>Select model...</option>
+                        <option value="GPT-4">GPT-4</option>
+                        <option value="TogetherAI">TogetherAI</option>
+                        <option value="Gemini">Gemini</option>
                     </select>
                 </div>
 
@@ -239,6 +242,7 @@
         <div class="mobile-logs-section">
             <div class="mobile-logs-header">Chat history cleared</div>
             <div class="mobile-logs-header">Message counters have been reset</div>
+            <div class="mobile-logs-header model-info"></div>
         </div>
     </div>
 

--- a/static/styles/chat_style.css
+++ b/static/styles/chat_style.css
@@ -94,6 +94,14 @@ body {
     text-shadow: 0 0 10px currentColor;
 }
 
+.logs-header.model-info {
+    position: sticky;
+    top: 0;
+    text-align: center;
+    background: rgba(10, 10, 15, 0.8);
+    z-index: 1;
+}
+
 .logs-content {
     flex: 1;
     min-height: 0;
@@ -1347,6 +1355,14 @@ body {
         margin-bottom: 10px;
         font-size: 11px;
         flex-shrink: 0;
+        background: rgba(10, 10, 15, 0.8);
+    }
+
+    .mobile-logs-header.model-info {
+        position: sticky;
+        top: 0;
+        text-align: center;
+        z-index: 1;
     }
 
     .mobile-logs-content {
@@ -1588,6 +1604,29 @@ body {
     cursor: pointer;
     color: var(--text-secondary);
     transition: all 0.3s ease;
+}
+
+.api-keys-form .use-service-key {
+    background: linear-gradient(135deg, rgba(26, 10, 46, 0.9), rgba(16, 33, 62, 0.8));
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    margin-top: 10px;
+    padding: 6px 8px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: all 0.3s ease;
+}
+
+.api-keys-form .use-service-key:hover {
+    border-color: var(--border-hover);
+    color: var(--text-primary);
+    box-shadow: 0 0 10px rgba(53, 127, 236, 0.3);
+    transform: translateY(2px);
+}
+
+.api-keys-form .use-service-key:active {
+    background: #333;
+    transform: translateY(1px);
 }
 
 .api-keys-form .save-keys:hover {


### PR DESCRIPTION
## Summary
- update model dropdown options
- ensure selected model and keys load from local storage
- provide "Use Service Key" option and style it
- show current model and API key in log headers
- refresh API keys from inputs when sending a dialog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685481dba5d48326ad353dc636a49c93