### PR TITLE
Default TogetherAI and service key

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -29,9 +29,8 @@
                     <div class="control-group">
                         <label>Select model</label>
                         <select>
-                            <option value="" selected>Select model...</option>
+                            <option value="TogetherAI" selected>TogetherAI</option>
                             <option value="GPT-4">GPT-4</option>
-                            <option value="TogetherAI">TogetherAI</option>
                             <option value="Gemini">Gemini</option>
                         </select>
                     </div>
@@ -197,9 +196,8 @@
                 <div class="mobile-control-group">
                     <label>Select model</label>
                     <select>
-                        <option value="" selected>Select model...</option>
+                        <option value="TogetherAI" selected>TogetherAI</option>
                         <option value="GPT-4">GPT-4</option>
-                        <option value="TogetherAI">TogetherAI</option>
                         <option value="Gemini">Gemini</option>
                     </select>
                 </div>

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -21,8 +21,10 @@ class BotDialogGenerator {
       bot1: 0.7,
       bot2: 0.7,
     };
-    this.selectedModel = "";
-    this.useServiceKey = localStorage.getItem("useServiceKey") === "true";
+    // Default to TogetherAI with a service key unless user saved another choice
+    this.selectedModel = "TogetherAI";
+    const stored = localStorage.getItem("useServiceKey");
+    this.useServiceKey = stored === null ? true : stored === "true";
 
     this.init();
   }
@@ -444,7 +446,8 @@ class BotDialogGenerator {
     const openai = localStorage.getItem("openaiKey") || "";
     const together = localStorage.getItem("togetheraiKey") || "";
     const google = localStorage.getItem("googleKey") || "";
-    this.useServiceKey = localStorage.getItem("useServiceKey") === "true";
+    const stored = localStorage.getItem("useServiceKey");
+    this.useServiceKey = stored === null ? true : stored === "true";
 
     if (openai) {
       this.apiKeys.openai = openai;


### PR DESCRIPTION
## Summary
- set TogetherAI as the default model and remove the placeholder option
- use TogetherAI service key by default so no API keys are required on first use

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68549a18de108326950256f28a786007