### PR TITLE
Add model and key info header

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -19,9 +19,11 @@
     <main class="container"> <!-- Левый контейнер -->
         <div class="left-panel">
             <div class="logs-section">
-                <div class="logs-header">Chat history cleared</div>
-                <div class="logs-header">Message counters have been reset</div>
                 <div class="logs-header model-info"></div>
+                <div class="logs-content">
+                    <div class="logs-header">Chat history cleared</div>
+                    <div class="logs-header">Message counters have been reset</div>
+                </div>
             </div>
 
             <div class="settings-section"> <!-- Блок с настройками -->
@@ -238,9 +240,11 @@
 
     <div class="mobile-section" id="logs-section">
         <div class="mobile-logs-section">
-            <div class="mobile-logs-header">Chat history cleared</div>
-            <div class="mobile-logs-header">Message counters have been reset</div>
             <div class="mobile-logs-header model-info"></div>
+            <div class="mobile-logs-content">
+                <div class="mobile-logs-header">Chat history cleared</div>
+                <div class="mobile-logs-header">Message counters have been reset</div>
+            </div>
         </div>
     </div>
 

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -1265,7 +1265,7 @@ class BotDialogGenerator {
 
   clearLogs() {
     const logAreas = document.querySelectorAll(
-      ".logs-section, .mobile-logs-section"
+      ".logs-content, .mobile-logs-content"
     );
     logAreas.forEach((logArea) => {
       logArea.innerHTML = "";
@@ -1279,7 +1279,7 @@ class BotDialogGenerator {
 
   logMessage(message, type = "info") {
     const logAreas = document.querySelectorAll(
-      ".logs-section, .mobile-logs-section"
+      ".logs-content, .mobile-logs-content"
     );
     logAreas.forEach((logArea) => {
       // Clear example text on first real log

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -1317,20 +1317,28 @@ class BotDialogGenerator {
 
   updateModelInfo() {
     const model = this.selectedModel || "none";
-    const keyMap = {
-      "GPT-4": this.apiKeys.openai,
-      TogetherAI: this.useServiceKey ? "service" : this.apiKeys.togetherai,
-      Gemini: this.apiKeys.google,
-    };
-    const key = keyMap[model] || "";
-    let shortKey;
-    if (model === "TogetherAI" && this.useServiceKey) {
-      shortKey = "service key";
-    } else {
-      shortKey = key ? `${key.slice(0, 4)}...${key.slice(-4)}` : "no key";
+    let keyText = "";
+    let key = "";
+
+    if (model === "GPT-4") {
+      key = this.apiKeys.openai;
+    } else if (model === "TogetherAI") {
+      if (this.useServiceKey) {
+        keyText = "Srvice Key";
+      } else {
+        key = this.apiKeys.togetherai;
+      }
+    } else if (model === "Gemini") {
+      key = this.apiKeys.google;
     }
+
+    if (!keyText) {
+      const shortKey = key ? `${key.slice(0, 2)}...${key.slice(-3)}` : "no key";
+      keyText = `User Key: ${shortKey}`;
+    }
+
     document.querySelectorAll(".model-info").forEach((el) => {
-      el.textContent = `${model} | ${shortKey}`;
+      el.textContent = `${model} | ${keyText}`;
     });
   }
 }

--- a/static/styles/chat_style.css
+++ b/static/styles/chat_style.css
@@ -81,7 +81,6 @@ body {
     backdrop-filter: blur(10px);
     position: relative;
     overflow: hidden;
-    overflow-y: auto;
 }
 
 .logs-header {
@@ -95,16 +94,14 @@ body {
 }
 
 .logs-header.model-info {
-    position: sticky;
-    top: 0;
     text-align: center;
     background: rgba(10, 10, 15, 0.8);
-    z-index: 1;
 }
 
 .logs-content {
     flex: 1;
     min-height: 0;
+    overflow-y: auto;
 }
 
 .settings-section {
@@ -1341,7 +1338,6 @@ body {
         border-radius: 8px;
         padding: 15px;
         flex: 1;
-        overflow-y: auto;
         font-family: 'Courier New', monospace;
         font-size: 12px;
         min-height: 200px;
@@ -1358,10 +1354,7 @@ body {
     }
 
     .mobile-logs-header.model-info {
-        position: sticky;
-        top: 0;
         text-align: center;
-        z-index: 1;
     }
 
     .mobile-logs-content {


### PR DESCRIPTION
## Summary
- show currently selected model and API key info in the logs header

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6854a07cea3c832699eaa574a3bf1721