### PR TITLE
Add navigation to chat page

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -15,6 +15,14 @@
 </head>
 
 <body>
+    <!-- Navigation -->
+    <header class="top-bar">
+        <div class="nav-left">
+            <a href="index.html">Home</a>
+            <a href="welcome.html">Application</a>
+        </div>
+    </header>
+
     <!-- Desktop Layout -->
     <main class="container"> <!-- Левый контейнер -->
         <div class="left-panel">
@@ -66,13 +74,13 @@
 
         <div class="right-panel"> <!-- Правый контейнер  -->
             <div class="dialog-section"> <!-- Секция с диалогом  -->
+                <button class="control-button fullscreen">
+                    <img src="static/image/full_screen.png" alt="Full Screen">
+                </button>
                 <div class="dialog-header">
-                    
+
                 </div>
             </div>
-            <button class="control-button fullscreen">
-                <img src="static/image/full_screen.png" alt="Full Screen">
-            </button>
 
             <div class="bot-profiles"> <!-- Группа с двумя полями для ввода системного промпта  -->
                 <div class="bot-profile"> <!-- Блок с полем системного промпта одного бота  -->

--- a/static/styles/chat_style.css
+++ b/static/styles/chat_style.css
@@ -42,13 +42,66 @@ body {
     position: relative;
 }
 
+/* Navigation */
+.top-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    padding: 20px 40px;
+    z-index: 1000;
+    transition: all 0.3s ease;
+}
+
+.nav-left {
+    display: flex;
+    gap: 10px;
+}
+
+.top-bar a {
+    color: #fff;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 16px;
+    transition: all 0.3s ease;
+    position: relative;
+    padding: 8px 10px;
+    border-radius: 8px;
+}
+
+.top-bar a:hover {
+    cursor: pointer;
+    color: #00ffff;
+    transform: translateY(-2px);
+}
+
+.top-bar a::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: 0;
+    height: 2px;
+    background: linear-gradient(90deg, #00ffff, #ff00ff);
+    transition: all 0.3s ease;
+    transform: translateX(-50%);
+}
+
+.top-bar a:hover::after {
+    width: 80%;
+}
+
 /* Desktop Layout */
 .container {
     display: grid;
     grid-template-columns: minmax(350px, 400px) 1fr;
-    height: 100vh;
+    height: calc(100vh - 80px);
     gap: 15px;
     padding: 15px;
+    margin-top: 80px;
     overflow: hidden;
     overflow-y: auto;
 }
@@ -989,10 +1042,10 @@ body {
 }
 
 .control-button.fullscreen {
-    position: fixed;
+    position: absolute;
     padding: 10px 15px;
-    top: 40px;
-    right: 45px;
+    top: 15px;
+    right: 20px;
     z-index: 999;
     color: var(--accent-info);
     border-color: var(--accent-info);
@@ -1120,6 +1173,11 @@ body {
         margin-bottom: 15px;
         gap: 8px;
         flex-shrink: 0;
+    }
+
+    .control-button.fullscreen {
+        position: static;
+        margin-left: auto;
     }
 
     .mobile-chat-content {


### PR DESCRIPTION
## Summary
- add header nav with links to main and application pages
- style the new navigation bar
- fix nav layout so buttons appear top-left and do not overlap content
- anchor fullscreen button to the dialog section so it moves with page content

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68594244e77c832691c00704f0ada4cd