### PR TITLE
Validate Together API key and use standard Referer header

### DIFF
--- a/api/together.js
+++ b/api/together.js
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
       headers: (apiKey) => ({
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
-        "HTTP-Referer": req.headers.origin || "https://cyborg-id.vercel.app/", // fallback
+        Referer: req.headers.origin || "https://cyborg-id.vercel.app/", // fallback
         "X-Title": "Form Application",
       }),
       models: {
@@ -44,6 +44,10 @@ export default async function handler(req, res) {
   const modelName = selectedProvider.models[mode || "autofill"];
   if (!modelName) {
     return res.status(400).json({ error: "Invalid mode or model not found" });
+  }
+
+  if (!TOGETHER_API_KEY) {
+    return res.status(500).json({ error: "Missing Together API key" });
   }
 
   try {

--- a/api/together.test.js
+++ b/api/together.test.js
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from './together.js';
+
+const originalFetch = global.fetch;
+
+function createRes() {
+  return {
+    statusCode: null,
+    jsonData: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.jsonData = data;
+      return this;
+    },
+  };
+}
+
+test('returns 500 when API key missing', async () => {
+  delete process.env.TOGETHER_API_KEY;
+  global.fetch = () => {
+    throw new Error('fetch should not be called');
+  };
+
+  const req = {
+    body: {
+      systemPrompt: 'sys',
+      userPrompt: 'hi',
+      temperature: 0.5,
+      provider: 'META_LLAMA',
+      mode: 'autofill',
+    },
+    headers: {},
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.jsonData, { error: 'Missing Together API key' });
+
+  global.fetch = originalFetch;
+});
+
+test('uses Referer header for QWEN2 provider', async () => {
+  let receivedHeaders;
+  global.fetch = async (url, options) => {
+    receivedHeaders = options.headers;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ message: 'ok' }),
+    };
+  };
+
+  const req = {
+    body: {
+      systemPrompt: 'sys',
+      userPrompt: 'hi',
+      temperature: 0.5,
+      provider: 'QWEN2',
+      mode: 'autofill',
+      apiKey: 'test',
+    },
+    headers: { origin: 'https://example.com' },
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(receivedHeaders.Referer, 'https://example.com');
+  assert.ok(!('HTTP-Referer' in receivedHeaders));
+
+  global.fetch = originalFetch;
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cyborgid",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}


### PR DESCRIPTION
## Summary
- return a 500 error when TOGETHER_API_KEY is missing
- send standard `Referer` header for QWEN2 requests
- add tests for missing API key and header usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978b7104c88326a741d32e01b42c85