### PR TITLE
Add dark theme to welcome page

### DIFF
--- a/welcome.html
+++ b/welcome.html
@@ -8,6 +8,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <!-- Font -->
   <link rel="icon" href="static/image/Cyborg_Logo2.png">
+  <style>
+    html, body { background-color: #000; color: #fff; }
+  </style>
   <link rel="stylesheet" href="static/styles/welcome_style.css">
 </head>
 


### PR DESCRIPTION
## Summary
- Add head style block to set black background and white text on welcome page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ae9c88348326be06007025b606e7