### PR TITLE
Align instruction headings to the left

### DIFF
--- a/static/styles/index_style.css
+++ b/static/styles/index_style.css
@@ -150,6 +150,10 @@ body {
     margin-bottom: 30px;
 }
 
+.sidebar-content .instruction h3 {
+    text-align: left;
+}
+
 .sidebar-content .instruction-image {
     width: 100%;
     border-radius: 10px;


### PR DESCRIPTION
## Summary
- ensure instruction-only `<h3>` elements in the sidebar align left

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c5a860888326a14988f85d439827