### PR TITLE
Add fade-out transition before avatar creation

### DIFF
--- a/static/scripts/index.js
+++ b/static/scripts/index.js
@@ -119,6 +119,21 @@ document.addEventListener("DOMContentLoaded", function () {
         "linear-gradient(135deg, #000428, #004e92)";
     });
   }
+
+  const createBtn = document.querySelector(".create-avater-button");
+  if (createBtn) {
+    createBtn.addEventListener("click", function (e) {
+      e.preventDefault();
+      document.body.classList.add("fade-out");
+      document.body.addEventListener(
+        "animationend",
+        function () {
+          window.location.href = "welcome.html";
+        },
+        { once: true }
+      );
+    });
+  }
 });
 
 // Performance optimization: Pause video when tab is not visible

--- a/static/styles/index_style.css
+++ b/static/styles/index_style.css
@@ -406,6 +406,16 @@ body {
     }
 }
 
+.fade-out {
+    animation: fadeOutPage 0.5s forwards;
+}
+
+@keyframes fadeOutPage {
+    to {
+        opacity: 0;
+    }
+}
+
 /* Loading Animation */
 .video-header::after {
     content: '';

--- a/welcome.html
+++ b/welcome.html
@@ -13,7 +13,7 @@
 
 <!-- Header -->
 
-<body>
+<body style="background:#000;color:#fff;">
   <main class="container">
     <div class="header">
       <h1>Application Form</h1>


### PR DESCRIPTION
## Summary
- Style `welcome.html` with a dark background and light text.
- Introduce a fade-out animation on the index page before navigating to the avatar creation form.
- Define CSS keyframes and class for fading out the page.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e950640c8326b57f4823b20f043d