### PR TITLE
Add admin page checks for API keys and models

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -1,0 +1,15 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+button {
+  margin: 5px 0;
+  padding: 8px 16px;
+}
+
+pre {
+  background: #f0f0f0;
+  padding: 10px;
+  white-space: pre-wrap;
+}

--- a/admin.html
+++ b/admin.html
@@ -6,6 +6,11 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-
+  <h1>Admin Panel</h1>
+  <button id="checkKeysBtn">Check API Keys</button>
+  <pre id="keysResult"></pre>
+  <button id="checkModelsBtn">Check Models</button>
+  <pre id="modelsResult"></pre>
+  <script src="static/scripts/admin.js"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Admin</title>
-  <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="admin.css" />
 </head>
 <body>
   <h1>Admin Panel</h1>

--- a/api/checkKeys.js
+++ b/api/checkKeys.js
@@ -1,0 +1,47 @@
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const result = {};
+
+  // Check Supabase Service Key
+  const SUPABASE_URL = "https://uomyodvgfgtvmbqjeazm.supabase.co";
+  const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
+  if (!supabaseKey) {
+    result.supabase = { ok: false, error: "Missing SUPABASE_SERVICE_KEY" };
+  } else {
+    try {
+      const response = await fetch(
+        `${SUPABASE_URL}/rest/v1/user_profiles?select=id&limit=1`,
+        {
+          headers: {
+            apikey: supabaseKey,
+            Authorization: `Bearer ${supabaseKey}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      result.supabase = { ok: response.ok, status: response.status };
+    } catch (err) {
+      result.supabase = { ok: false, error: err.message };
+    }
+  }
+
+  // Check Together AI Key
+  const togetherKey = process.env.TOGETHER_API_KEY;
+  if (!togetherKey) {
+    result.together = { ok: false, error: "Missing TOGETHER_API_KEY" };
+  } else {
+    try {
+      const response = await fetch("https://api.together.xyz/v1/models", {
+        headers: { Authorization: `Bearer ${togetherKey}` },
+      });
+      result.together = { ok: response.ok, status: response.status };
+    } catch (err) {
+      result.together = { ok: false, error: err.message };
+    }
+  }
+
+  return res.status(200).json(result);
+}

--- a/api/checkModels.js
+++ b/api/checkModels.js
@@ -8,6 +8,12 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: "Missing Together API key" });
   }
 
+  // Models currently used in the application
+  const REQUIRED_MODELS = [
+    "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
+    "Qwen/Qwen2-VL-72B-Instruct",
+  ];
+
   try {
     const response = await fetch("https://api.together.xyz/v1/models", {
       headers: { Authorization: `Bearer ${apiKey}` },
@@ -18,7 +24,18 @@ export default async function handler(req, res) {
       return res.status(response.status).json(data);
     }
 
-    return res.status(200).json(data);
+    // Collect available model ids
+    const available = new Set(
+      Array.isArray(data?.data) ? data.data.map((m) => m.id) : []
+    );
+
+    // Return availability for required models only
+    const result = {};
+    for (const model of REQUIRED_MODELS) {
+      result[model] = available.has(model);
+    }
+
+    return res.status(200).json(result);
   } catch (err) {
     return res.status(500).json({ error: "Server error", message: err.message });
   }

--- a/api/checkModels.js
+++ b/api/checkModels.js
@@ -1,0 +1,25 @@
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const apiKey = process.env.TOGETHER_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: "Missing Together API key" });
+  }
+
+  try {
+    const response = await fetch("https://api.together.xyz/v1/models", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const data = await response.json();
+
+    if (!response.ok) {
+      return res.status(response.status).json(data);
+    }
+
+    return res.status(200).json(data);
+  } catch (err) {
+    return res.status(500).json({ error: "Server error", message: err.message });
+  }
+}

--- a/static/scripts/admin.js
+++ b/static/scripts/admin.js
@@ -1,0 +1,30 @@
+async function checkKeys() {
+  try {
+    const res = await fetch("/api/checkKeys");
+    const data = await res.json();
+    document.getElementById("keysResult").textContent = JSON.stringify(
+      data,
+      null,
+      2
+    );
+  } catch (err) {
+    document.getElementById("keysResult").textContent = err.message;
+  }
+}
+
+async function checkModels() {
+  try {
+    const res = await fetch("/api/checkModels");
+    const data = await res.json();
+    document.getElementById("modelsResult").textContent = JSON.stringify(
+      data,
+      null,
+      2
+    );
+  } catch (err) {
+    document.getElementById("modelsResult").textContent = err.message;
+  }
+}
+
+document.getElementById("checkKeysBtn").addEventListener("click", checkKeys);
+document.getElementById("checkModelsBtn").addEventListener("click", checkModels);

--- a/static/scripts/admin.js
+++ b/static/scripts/admin.js
@@ -16,11 +16,13 @@ async function checkModels() {
   try {
     const res = await fetch("/api/checkModels");
     const data = await res.json();
-    document.getElementById("modelsResult").textContent = JSON.stringify(
-      data,
-      null,
-      2
-    );
+    const lines = Object.entries(data).map(([model, info]) => {
+      if (info.available) {
+        return `${model}: ok`;
+      }
+      return `${model}: error - ${info.error || "unknown"}`;
+    });
+    document.getElementById("modelsResult").textContent = lines.join("\n");
   } catch (err) {
     document.getElementById("modelsResult").textContent = err.message;
   }


### PR DESCRIPTION
## Summary
- add admin panel buttons to verify API keys and available models
- implement API endpoints to test Supabase/Together keys and list models
- add client-side script to call checks and display results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899c01a808883269695ccd2c6b7aa04