### PR TITLE
feat: update Qwen provider to v3

### DIFF
--- a/api/together.js
+++ b/api/together.js
@@ -19,7 +19,7 @@ export default async function handler(req, res) {
         summary: "meta-llama/llama-3.3-70b-instruct",
       },
     },
-    QWEN2: {
+    QWEN3: {
       name: "Qwen3",
       url: "https://openrouter.ai/api/v1/chat/completions",
       headers: (apiKey) => ({
@@ -29,8 +29,8 @@ export default async function handler(req, res) {
         "X-Title": "Form Application",
       }),
       models: {
-        autofill: "qwen/qwen3-30b-a3b-thinking-2507",
-        summary: "qwen/qwen3-30b-a3b-thinking-2507",
+        autofill: "qwen/qwen3-30b-a3b-thinking-2507", // модель Qwen3
+        summary: "qwen/qwen3-30b-a3b-thinking-2507", // модель Qwen3
       },
     },
   };

--- a/api/together.test.js
+++ b/api/together.test.js
@@ -20,7 +20,8 @@ function createRes() {
 }
 
 test('returns 500 when API key missing', async () => {
-  delete process.env.TOGETHER_API_KEY;
+  const originalKey = process.env.OPENROUTER_API_KEY;
+  delete process.env.OPENROUTER_API_KEY;
   global.fetch = () => {
     throw new Error('fetch should not be called');
   };
@@ -40,12 +41,13 @@ test('returns 500 when API key missing', async () => {
   await handler(req, res);
 
   assert.equal(res.statusCode, 500);
-  assert.deepEqual(res.jsonData, { error: 'Missing Together API key' });
+  assert.deepEqual(res.jsonData, { error: 'Missing OpenRouter API key' });
 
   global.fetch = originalFetch;
+  process.env.OPENROUTER_API_KEY = originalKey;
 });
 
-test('uses Referer header for QWEN2 provider', async () => {
+test('uses HTTP-Referer header for QWEN3 provider', async () => {
   let receivedHeaders;
   global.fetch = async (url, options) => {
     receivedHeaders = options.headers;
@@ -61,7 +63,7 @@ test('uses Referer header for QWEN2 provider', async () => {
       systemPrompt: 'sys',
       userPrompt: 'hi',
       temperature: 0.5,
-      provider: 'QWEN2',
+      provider: 'QWEN3',
       mode: 'autofill',
       apiKey: 'test',
     },
@@ -72,8 +74,8 @@ test('uses Referer header for QWEN2 provider', async () => {
   await handler(req, res);
 
   assert.equal(res.statusCode, 200);
-  assert.equal(receivedHeaders.Referer, 'https://example.com');
-  assert.ok(!('HTTP-Referer' in receivedHeaders));
+  assert.equal(receivedHeaders['HTTP-Referer'], 'https://example.com');
+  assert.ok(!('Referer' in receivedHeaders));
 
   global.fetch = originalFetch;
 });

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -1028,7 +1028,7 @@ class BotDialogGenerator {
       throw new Error("Missing TogetherAI API key");
     }
     const providers = [
-      { provider: "QWEN2", name: "Qwen2" },
+      { provider: "QWEN3", name: "Qwen3" },
       { provider: "META_LLAMA", name: "Meta Llama" },
     ];
 

--- a/static/scripts/welcome.js
+++ b/static/scripts/welcome.js
@@ -7,11 +7,11 @@ const AI_PROVIDERS = {
       summary: "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free"
     }
   },
-  QWEN2: {
-    name: "Qwen2",
+  QWEN3: {
+    name: "Qwen3",
     models: {
-      autofill: "Qwen/Qwen2-VL-72B-Instruct",
-      summary: "Qwen/Qwen2-VL-72B-Instruct"
+      autofill: "qwen/qwen3-30b-a3b-thinking-2507",
+      summary: "qwen/qwen3-30b-a3b-thinking-2507"
     }
   }
 };
@@ -157,8 +157,8 @@ async function callAIWithFallback(prompt, systemPrompt, taskType = 'autofill') {
       providerKey: "META_LLAMA",
     },
     {
-      config: AI_PROVIDERS.QWEN2,
-      providerKey: "QWEN2",
+      config: AI_PROVIDERS.QWEN3,
+      providerKey: "QWEN3",
     }
   ];
 


### PR DESCRIPTION
## Summary
- switch Together AI Qwen provider to QWEN3 with updated model ids
- align front-end provider lists and fallback logic to QWEN3
- refresh tests to use OPENROUTER_API_KEY and HTTP-Referer header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3075bb1288326a01f1c49e8c41cfb