### PR TITLE
Align Meta-Llama model identifier across UI and API

### DIFF
--- a/static/scripts/welcome.js
+++ b/static/scripts/welcome.js
@@ -3,8 +3,8 @@ const AI_PROVIDERS = {
   META_LLAMA: {
     name: "Meta Llama",
     models: {
-      autofill: "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free",
-      summary: "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free"
+      autofill: "meta-llama/llama-3.3-70b-instruct",
+      summary: "meta-llama/llama-3.3-70b-instruct"
     }
   },
   QWEN3: {


### PR DESCRIPTION
## Summary
- standardize Meta Llama model reference in UI to `meta-llama/llama-3.3-70b-instruct` to match API configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30f71609c8326829cbf5c341aa857