### PR TITLE
test: ensure HTTP-Referer for META_LLAMA

### DIFF
--- a/api/openrouter.test.js
+++ b/api/openrouter.test.js
@@ -79,3 +79,36 @@ test('uses HTTP-Referer header for QWEN3 provider', async () => {
 
   global.fetch = originalFetch;
 });
+
+test('uses HTTP-Referer header for META_LLAMA provider', async () => {
+  let receivedHeaders;
+  global.fetch = async (url, options) => {
+    receivedHeaders = options.headers;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ message: 'ok' }),
+    };
+  };
+
+  const req = {
+    body: {
+      systemPrompt: 'sys',
+      userPrompt: 'hi',
+      temperature: 0.5,
+      provider: 'META_LLAMA',
+      mode: 'autofill',
+      apiKey: 'test',
+    },
+    headers: { origin: 'https://example.com' },
+  };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(receivedHeaders['HTTP-Referer'], 'https://example.com');
+  assert.ok(!('Referer' in receivedHeaders));
+
+  global.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- add test confirming META_LLAMA requests send HTTP-Referer header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3105a76b88326b37aa9ecc3722f08