### PR TITLE
Increase AI response variability

### DIFF
--- a/api/openrouter.js
+++ b/api/openrouter.js
@@ -1,5 +1,5 @@
 export default async function handler(req, res) {
-  const { systemPrompt, userPrompt, temperature, provider, mode, apiKey } = req.body;
+  const { systemPrompt, userPrompt, temperature, provider, mode, apiKey, top_p, seed } = req.body;
 
   const OPENROUTER_API_KEY = apiKey || process.env.OPENROUTER_API_KEY;
 
@@ -62,7 +62,9 @@ export default async function handler(req, res) {
           },
           { role: "user", content: userPrompt },
         ],
-        temperature: temperature,
+        temperature,
+        top_p,
+        seed,
         max_tokens: 500,
       }),
     });

--- a/static/scripts/welcome.js
+++ b/static/scripts/welcome.js
@@ -174,7 +174,9 @@ async function callAIWithFallback(prompt, systemPrompt, taskType = 'autofill') {
       const requestBody = {
         systemPrompt: systemPrompt,
         userPrompt: prompt,
-        temperature: taskType === 'autofill' ? 0.7 : 0.4,
+        temperature: taskType === 'autofill' ? 1.3 : 1.1,
+        top_p: 0.9,
+        seed: Math.floor(Math.random() * 1000000),
         provider: providerKey,
         mode: taskType,
       };


### PR DESCRIPTION
## Summary
- raise temperature for autofill and summary requests to encourage diverse AI output
- add `top_p` and random `seed` parameters in client and forward them through OpenRouter API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3126d5bc883269606e85d5c2bff27