### PR TITLE
Increase default message limit

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -62,7 +62,7 @@
                     <div class="control-group"> <!-- Лимит сообщений  -->
                         <label>Message limit</label>
                         <div class="number-input">
-                            <input type="number" value="2" min="1" max="100">
+                            <input type="number" value="20" min="1" max="100">
                             <button class="refresh-btn">
                                 <img src="static/image/refresh.png" alt="refresh">
                             </button>
@@ -222,7 +222,7 @@
                 <div class="mobile-control-group">
                     <label>Message limit</label>
                     <div class="number-input">
-                        <input type="number" value="2" min="1" max="100">
+                        <input type="number" value="20" min="1" max="100">
                     </div>
                 </div>
             </div>

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -2,7 +2,7 @@ class BotDialogGenerator {
   constructor() {
     this.isGenerating = false;
     this.isPaused = false;
-    this.messageLimit = 2;
+    this.messageLimit = 20;
     this.users = [];
     this.currentBatchCount = 0; // Количество сообщений в текущей пачке генерации
     this.generatedMessages = []; // Сгенерированные сообщения
@@ -123,7 +123,7 @@ class BotDialogGenerator {
     // Message limit input
     document.querySelectorAll('input[type="number"]').forEach((input) => {
       input.addEventListener("change", (e) => {
-        this.messageLimit = parseInt(e.target.value) || 2;
+        this.messageLimit = parseInt(e.target.value) || 20;
       });
     });
 


### PR DESCRIPTION
## Summary
- raise default message limit input values from 2 to 20
- update script to use 20 as the default/fallback message limit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b313c7ab108326b2e241c3dde08ec4