### PR TITLE
Style creativity sliders and rename bots

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -93,7 +93,7 @@
                             </select>
                         </div>
                     </div>
-                    <textarea placeholder="Enter system prompt for Bot 1..."></textarea>
+                    <textarea placeholder="Enter system prompt for User 1..."></textarea>
                 </div>
                 <div class="bot-profile"> <!-- Блок с полем системного промпта одного бота  -->
                     <div class="bot-profile-header">
@@ -105,7 +105,7 @@
                             </select>
                         </div>
                     </div>
-                    <textarea placeholder="Enter system prompt for Bot 2..."></textarea>
+                    <textarea placeholder="Enter system prompt for User 2..."></textarea>
                 </div>
             </div>
 
@@ -177,7 +177,7 @@
                         <option>Default User</option>
                     </select>
                 </div>
-                <textarea class="mobile-bot-textarea" placeholder="Enter system prompt for Bot 1..."></textarea>
+                <textarea class="mobile-bot-textarea" placeholder="Enter system prompt for User 1..."></textarea>
             </div>
 
             <div class="mobile-bot-card">
@@ -188,7 +188,7 @@
                         <option>Default User</option>
                     </select>
                 </div>
-                <textarea class="mobile-bot-textarea" placeholder="Enter system prompt for Bot 2..."></textarea>
+                <textarea class="mobile-bot-textarea" placeholder="Enter system prompt for User 2..."></textarea>
             </div>
         </div>
     </div>

--- a/static/scripts/chat.js
+++ b/static/scripts/chat.js
@@ -355,11 +355,11 @@ class BotDialogGenerator {
         content.innerHTML = `
                 <div class="creativity-controls">
                     <div class="slider-group">
-                        <label>Bot 1 Temperature: <span id="temp1-value">0.7</span></label>
+                        <label>User 1 Temperature: <span id="temp1-value">0.7</span></label>
                         <input type="range" id="temp1-slider" min="0" max="2" step="0.1" value="0.7">
                     </div>
                     <div class="slider-group">
-                        <label>Bot 2 Temperature: <span id="temp2-value">0.7</span></label>
+                        <label>User 2 Temperature: <span id="temp2-value">0.7</span></label>
                         <input type="range" id="temp2-slider" min="0" max="2" step="0.1" value="0.7">
                     </div>
                 </div>

--- a/static/styles/chat_style.css
+++ b/static/styles/chat_style.css
@@ -1673,9 +1673,102 @@ body {
     margin-bottom: 15px;
 }
 
+.creativity-controls .slider-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-size: 14px;
+    color: var(--text-secondary);
+    text-shadow: 0 0 10px currentColor;
+}
+
 .creativity-controls input[type="range"] {
+    appearance: none;
+    -webkit-appearance: none;
     width: 100%;
+    height: 6px;
     margin-top: 5px;
+    background: linear-gradient(to right,
+            rgba(20, 20, 30, 0.8) 0%,
+            rgba(40, 40, 60, 0.6) 100%);
+    border: 1px solid rgba(0, 200, 255, 0.2);
+    border-radius: 3px;
+    outline: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.4),
+        0 1px 2px rgba(0, 200, 255, 0.1);
+}
+
+.creativity-controls input[type="range"]:hover {
+    border-color: rgba(0, 200, 255, 0.4);
+    box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.4),
+        0 0 8px rgba(0, 200, 255, 0.15);
+}
+
+.creativity-controls input[type="range"]::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    background: linear-gradient(135deg,
+            rgba(0, 200, 255, 0.9) 0%,
+            rgba(0, 150, 255, 0.7) 100%);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow:
+        0 2px 6px rgba(0, 0, 0, 0.3),
+        0 0 8px rgba(0, 200, 255, 0.3),
+        inset 0 1px 2px rgba(255, 255, 255, 0.2);
+}
+
+.creativity-controls input[type="range"]::-webkit-slider-thumb:hover {
+    background: linear-gradient(135deg,
+            rgba(0, 220, 255, 1) 0%,
+            rgba(0, 170, 255, 0.8) 100%);
+    border-color: rgba(255, 255, 255, 0.4);
+    box-shadow:
+        0 4px 12px rgba(0, 0, 0, 0.4),
+        0 0 16px rgba(0, 200, 255, 0.5),
+        inset 0 1px 2px rgba(255, 255, 255, 0.3);
+    transform: scale(1.1);
+}
+
+.creativity-controls input[type="range"]::-webkit-slider-thumb:active {
+    transform: scale(0.95);
+    box-shadow:
+        0 2px 4px rgba(0, 0, 0, 0.4),
+        0 0 12px rgba(0, 200, 255, 0.6),
+        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Firefox thumb */
+.creativity-controls input[type="range"]::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    background: linear-gradient(135deg,
+            rgba(0, 200, 255, 0.9) 0%,
+            rgba(0, 150, 255, 0.7) 100%);
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow:
+        0 2px 6px rgba(0, 0, 0, 0.3),
+        0 0 8px rgba(0, 200, 255, 0.3);
+}
+
+/* Firefox track */
+.creativity-controls input[type="range"]::-moz-range-track {
+    height: 6px;
+    background: linear-gradient(to right,
+            rgba(20, 20, 30, 0.8) 0%,
+            rgba(40, 40, 60, 0.6) 100%);
+    border: 1px solid rgba(0, 200, 255, 0.2);
+    border-radius: 3px;
 }
 
 .thinking-indicator {


### PR DESCRIPTION
## Summary
- Replace "Bot 1/2" with "User 1/2" across creativity sliders and system prompt placeholders.
- Add themed styling for creativity sliders to match chat page aesthetics.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b314f8f3f88326aed05a77096c5e14