### PR TITLE
Adjust center logo spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,11 @@
             <source src="static/video/The Thing_3.mp4" type="video/mp4">
             Your browser does not support the video tag.
         </video>
-    </div>
 
-    <!-- Main Content -->
-    <div class="center-logo">
-        <h1>Welcome to <br> <span>Cyborg ID</span></h1>
+        <!-- Main Content -->
+        <div class="center-logo">
+            <h1>Welcome to <br> <span>Cyborg ID</span></h1>
+        </div>
     </div>
 
     <div class="buttons">

--- a/static/styles/index_style.css
+++ b/static/styles/index_style.css
@@ -254,9 +254,9 @@ body {
 /* Logo */
 .center-logo {
     position: absolute;
-    top: 68%;
+    bottom: 15%;
     left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translateX(-50%);
     text-align: center;
     z-index: 10;
     animation: fadeInDown 2s ease-out;
@@ -524,9 +524,9 @@ body {
     .video-header {
         height: 65vh;
     }
-    
+
     .center-logo {
-        top: 55%;
+        bottom: 15%;
     }
     
     .center-logo h1 {
@@ -576,8 +576,8 @@ body {
     }
 
     .center-logo {
-        top: 45%;
-    }    
+        bottom: 20%;
+    }
     
     .center-logo h1 {
         font-size: 45px;
@@ -628,7 +628,7 @@ body {
     }
     
     .center-logo {
-        top: 15%;
+        bottom: 10%;
         width: 95%;
     }
     
@@ -713,9 +713,9 @@ body {
     .video-header {
         height: 85vh;
     }
-    
+
     .center-logo {
-        top: 45%;
+        bottom: 12%;
     }
     
     .center-logo h1 {


### PR DESCRIPTION
## Summary
- move center logo inside video header so its position is based on the video frame
- position logo with bottom offsets across breakpoints for consistent spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b843d907f8832683a66afa1a9a9b6b